### PR TITLE
Add Redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ RUN curl -s -o awscli-bundle.zip "https://s3.amazonaws.com/aws-cli/awscli-bundle
     && chmod +x ./awscli-bundle/install \
     && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 
+# install redis
+RUN apt-get install -y redis-server
+
 # install sbt
 RUN curl -Ls -o sbt.tar.gz "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" \
     && tar -vxzf sbt.tar.gz \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scala-builder
 
-Dockerfile for creating builder container for scala applications. Contains SBT, AWS CLI, Docker, PostgreSQL 11, Flyway, and Serverless Framework.
+Dockerfile for creating builder container for scala applications. Contains SBT, AWS CLI, Docker, PostgreSQL 11, Redis, Flyway, and Serverless Framework.
 
 Container is automatically published on [docker hub](https://hub.docker.com/r/ahlops/scala-builder)
 


### PR DESCRIPTION
@kylerisse this is for telephony redis integration tests. Plan is to add a `service redis-server start` to the telephony-service config.yml.  Test run succeeded: https://app.circleci.com/pipelines/github/adhoclabs/telephony-service/304/workflows/83e5a1db-b8dd-4768-a7c5-a45fce1584a7/jobs/341