### PR TITLE
use postgres 13

### DIFF
--- a/bin/start_postgresdb.sh
+++ b/bin/start_postgresdb.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sudo -u postgres PGDATA=/var/lib/postgresql/data /usr/lib/postgresql/11/bin/pg_ctl start
+sudo -u postgres PGDATA=/var/lib/postgresql/data /usr/lib/postgresql/13/bin/pg_ctl start


### PR DESCRIPTION
I think this change is necessary in order to use postgres 13 instead of 11. 

This run on circleCI indicates we're still running postgres 11, even though the docker container seems to have been updated to install 13: https://app.circleci.com/pipelines/github/adhoclabs/data_service/604/workflows/f3e5b6d5-11ba-4a72-94d2-e5b0b4f2e6cb/jobs/1392
![image](https://user-images.githubusercontent.com/8864150/151881552-d11aa022-32c4-44c1-a1b5-3eac0b4d44f3.png)

I'm not sure how it's finding postgres 11 at this moment, but it is what's running during the build. 